### PR TITLE
fix(components.list.revo-list.filter): Generic type 'DOMAttributes<T>…

### DIFF
--- a/src/components/list/revo-list.filter.tsx
+++ b/src/components/list/revo-list.filter.tsx
@@ -2,7 +2,7 @@ import { h } from '@stencil/core';
 import { JSXBase } from '@stencil/core/internal';
 import { getItemLabel } from '../../utils/item.helpers';
 
-interface Props extends JSXBase.DOMAttributes {
+interface Props extends JSXBase.DOMAttributes<HTMLInputElement> {
   value?: string;
   filterValue?: string;
   source: any[];


### PR DESCRIPTION
…' requires 1 type argument(s)